### PR TITLE
Update to include 1.11 blocks/items

### DIFF
--- a/src/reference/inventory.haml
+++ b/src/reference/inventory.haml
@@ -2710,6 +2710,108 @@
                                         %code STRUCTURE_VOID
                                     %td.tags  block, 1.10
                                 %tr
+                                    %td.uid.text-muted 218
+                                    %td.data.text-muted
+                                    %td.name
+                                        %code OBSERVER
+                                    %td.tags  block, 1.11
+                                %tr
+                                    %td.uid.text-muted 219
+                                    %td.data.text-muted
+                                    %td.name
+                                        %code WHITE_SHULKER_BOX
+                                    %td.tags  block, 1.11
+                                %tr
+                                    %td.uid.text-muted 220
+                                    %td.data.text-muted
+                                    %td.name
+                                        %code ORANGE_SHULKER_BOX
+                                    %td.tags  block, 1.11
+                                %tr
+                                    %td.uid.text-muted 221
+                                    %td.data.text-muted
+                                    %td.name
+                                        %code MAGENTA_SHULKER_BOX
+                                    %td.tags  block, 1.11
+                                %tr
+                                    %td.uid.text-muted 222
+                                    %td.data.text-muted
+                                    %td.name
+                                        %code LIGHT_BLUE_SHULKER_BOX
+                                    %td.tags  block, 1.11
+                                %tr
+                                    %td.uid.text-muted 223
+                                    %td.data.text-muted
+                                    %td.name
+                                        %code YELLOW_SHULKER_BOX
+                                    %td.tags  block, 1.11
+                                %tr
+                                    %td.uid.text-muted 224
+                                    %td.data.text-muted
+                                    %td.name
+                                        %code LIME_SHULKER_BOX
+                                    %td.tags  block, 1.11
+                                %tr
+                                    %td.uid.text-muted 225
+                                    %td.data.text-muted
+                                    %td.name
+                                        %code PINK_SHULKER_BOX
+                                    %td.tags  block, 1.11
+                                %tr
+                                    %td.uid.text-muted 226
+                                    %td.data.text-muted
+                                    %td.name
+                                        %code GRAY_SHULKER_BOX
+                                    %td.tags  block, 1.11
+                                %tr
+                                    %td.uid.text-muted 227
+                                    %td.data.text-muted
+                                    %td.name
+                                        %code SILVER_SHULKER_BOX
+                                    %td.tags  block, 1.11
+                                %tr
+                                    %td.uid.text-muted 228
+                                    %td.data.text-muted
+                                    %td.name
+                                        %code CYAN_SHULKER_BOX
+                                    %td.tags  block, 1.11
+                                %tr
+                                    %td.uid.text-muted 229
+                                    %td.data.text-muted
+                                    %td.name
+                                        %code PURPLE_SHULKER_BOX
+                                    %td.tags  block, 1.11
+                                %tr
+                                    %td.uid.text-muted 230
+                                    %td.data.text-muted
+                                    %td.name
+                                        %code BLUE_SHULKER_BOX
+                                    %td.tags  block, 1.11
+                                %tr
+                                    %td.uid.text-muted 231
+                                    %td.data.text-muted
+                                    %td.name
+                                        %code BROWN_SHULKER_BOX
+                                    %td.tags  block, 1.11
+                                %tr
+                                    %td.uid.text-muted 232
+                                    %td.data.text-muted
+                                    %td.name
+                                        %code GREEN_SHULKER_BOX
+                                    %td.tags  block, 1.11
+                                %tr
+                                    %td.uid.text-muted 233
+                                    %td.data.text-muted
+                                    %td.name
+                                        %code RED_SHULKER_BOX
+                                    %td.tags  block, 1.11
+                                %tr
+                                    %td.uid.text-muted 234
+                                    %td.data.text-muted
+                                    %td.name
+                                        %code BLACK_SHULKER_BOX
+                                    %td.tags  block, 1.11
+                                %tr
                                     %td.uid.text-muted 255
                                     %td.data.text-muted
                                     %td.name
@@ -4087,6 +4189,24 @@
                                     %td.name
                                         %code BOAT_DARK_OAK
                                     %td.tags  item, 1.9
+                                %tr
+                                    %td.uid.text-muted 449
+                                    %td.data.text-muted
+                                    %td.name
+                                        %code TOTEM
+                                    %td.tags  item, 1.11
+                                %tr
+                                    %td.uid.text-muted 450
+                                    %td.data.text-muted
+                                    %td.name
+                                        %code SHULKER_SHELL
+                                    %td.tags  item, 1.11
+                                %tr
+                                    %td.uid.text-muted 452
+                                    %td.data.text-muted
+                                    %td.name
+                                        %code IRON_NUGGET
+                                    %td.tags  item, 1.11
                                 / Records ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~
                                 %tr
                                     %td.uid.text-muted 2256


### PR DESCRIPTION
ID 451 has been skipped because there is no item ID with 451 in it.

Changes
-
- Added Observer
- Added Shulker Blocks
- Add Totem of Undying
- Add Shulker Shell
- Added Iron Nugget

**NOTE:** Doesn't include damage values because strangely enough like the newer boats, they aren't grouped under the same block/ID anymore.