### PR TITLE
General grammar/spelling fixes, edit map phases/editions and authors

### DIFF
--- a/index.md
+++ b/index.md
@@ -23,7 +23,7 @@ Almost every text editor can create and edit XML files, however editors designed
 
 We recommend that you use [Atom](https://atom.io/) to create and edit XML files.
 
-To keep your XML file clean & readable you should indent lines using 4 spaces and only specify elements or attributes you intend to use. 
+To keep your XML file clean & readable you should indent lines using 4 spaces and only specify elements or attributes you intend to use.
 
 ### Releasing Your Map
 Before releasing your map for testing, you must package your map following [these guidelines](/guides/packaging/cleaning_files).
@@ -56,7 +56,7 @@ All attributes or sub-elements for a element or module are listed in a table and
             </tr>
             <tr>
                 <td><code>color</code></td>
-                <td><span class="label label-danger">Required</span>This examples color.</td>
+                <td><span class="label label-danger">Required</span> This example's color.</td>
                 <td><a href="/reference/colors"> Dye Color Name</a></td>
                 <td></td>
             </tr>

--- a/modules/main.md
+++ b/modules/main.md
@@ -209,7 +209,7 @@ The maps version should follow the versioning schema `major.minor.patch`.
           </span>
         </td>
         <td>
-          Phase of this map. Only maps with phase:`production` and edition:`standard` show up on the website.
+          Phase of this map. Only maps with phase `production` show up on the website.
         </td>
         <td>
           <code>development</code>
@@ -225,7 +225,7 @@ The maps version should follow the versioning schema `major.minor.patch`.
             <code>{{'<edition>' | escape_once}}</code>
           </span>
         </td>
-        <td>Edition of this map, describes which servers it is run on.</td>
+        <td>Edition of this map, describes which servers it is run on. Only maps with edition `standard` and/or phase `production` show up on the website.</td>
         <td>
           <code>standard</code>
           <code>ranked</code>
@@ -270,9 +270,9 @@ The maps version should follow the versioning schema `major.minor.patch`.
 <br/>
 
 #### Authors & Contributors {#authors_contributors}
-The authors and contributers elements provide information about who created and helped create the map. There can be multiple authors and contributors to a map. The contribution attribute should be used to specify what their contribution to the map was.
+The authors and contributors elements provide information about who created and helped create the map. There can be multiple authors and contributors to a map. The contribution attribute should be used to specify what their contribution to the map was.
 
-A players name should **not** be used to credit them, instead their UUID should be used. A UUID is a unique user identifier that is used to keep track of players even if they change their name. You can check player UUID's at [mcuuid.net](http://mcuuid.net). If an author or contributor is defined without a UUID that player will not get any mapmaker perks on the map.
+A players name should **not** be used to credit them, instead their UUID should be used. A UUID is a unique user identifier that is used to keep track of players even if they change their name. You can check player UUID's at [mcuuid.net](http://mcuuid.net). If an author or contributor is defined without a UUID that player will not get any mapmaker perks on the map. The mapmaker perks include being able to join the map as if they had a premium rank, and a designated map maker star.
 <h5>Author or Contributor Sub-elements</h5>
 <div class='table-responsive'>
   <table class='table table-striped table-condensed'>

--- a/modules/rules.md
+++ b/modules/rules.md
@@ -51,5 +51,5 @@ You can use the rules module to add custom rules to your map that are not alread
 Example
 
     <rules>
-        <rule>Do not intentional prolong the match by hiding or exiting the playing area.</rule>
+        <rule>Do not intentionally prolong the match by hiding or exiting the playing area.</rule>
     </rules>


### PR DESCRIPTION
I added a line on mapmaker perks when they play their own map, unless that changed. The lines about phases and map editions are also fixed and make more sense reading them. Do maps with neither of these tags show up on the website?