### PR TITLE
Fix double span on current proto version.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -69,7 +69,7 @@
             <ul class="nav navbar-nav pull-right">
                 <li>
                     <a href="/modules/proto">
-                        <span style="padding-right: 10px"><i class="fa fa-certificate"></i> Current map proto is<span>
+                        <span style="padding-right: 10px"><i class="fa fa-certificate"></i> Current map proto is</span>
                         <span class="badge badge-primary pull-right">{{site.current_proto}}</span>
                     </a>
                 </li>


### PR DESCRIPTION
Currently a second `span` is opened rather than closed at the end of the proto version line.