### PR TITLE
Fix default `permanent` value for KotH

### DIFF
--- a/modules/control_points.md
+++ b/modules/control_points.md
@@ -300,7 +300,7 @@ Control point give a certain amount of point to the team currently holding it. O
           false
         </td>
         <td>
-          true
+          false
         </td>
       </tr>
       <tr>


### PR DESCRIPTION
The default value within the control point code is always set to false no matter if its a legacy KotH or not. 
[projectares/PGM/src/main/java/tc/oc/pgm/control/point/ControlPointParser.java#L85](https://github.com/StratusNetwork/projectares/blob/master/PGM/src/main/java/tc/oc/pgm/control/point/ControlPointParser.java#L85)
